### PR TITLE
Fix issue with package compilation

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,4 +1,4 @@
-useDynLib(causalTree, .registration = TRUE, .fixes = "C_")
+useDynLib(survivalCausalTree, .registration = TRUE, .fixes = "C_")
 
 export(susan1, susan11, susan2, susan3, nonlinear1, constant, causalTree, honest.causalTree, na.causalTree, estimate.causalTree, causalTree.matrix, causalForest, propensityForest)
 


### PR DESCRIPTION
Package fails to compile because "causalTree.so" does not exist since package was renamed to "survivalCausalTree".